### PR TITLE
defining the 'define' function as deprecated

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -18,7 +18,7 @@ const differ = new Differ({
   }
 })
  
-const table = differ.define('table', {
+const table = differ.define.table({
   name: 'schema_name.table_name',
   cleanable: { foreignKeys: true },
   foreignKeys: [
@@ -54,7 +54,7 @@ const table = differ.define('table', {
   ]
 })
 
-differ.define('sequence', {
+differ.define.sequence({
   name: 'schema_name.table_name_id',
   start: 100
 })

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ const setup = async () => {
 
   const users = await differ.read.table({ name: 'users' })
   if (!users || users.columns.length !== 1) {
-    differ.define('table', {
+    differ.define.table({
       name: 'users',
       columns: [
         { name: 'id', type: 'bigint', primaryKey: true },

--- a/docs/sequence.md
+++ b/docs/sequence.md
@@ -4,7 +4,7 @@
 
 ```javascript
 const differ = new Differ(...)
-const sequence = differ.define('sequence', properties)
+const sequence = differ.define.sequence(properties)
 differ.sync().then(() => console.log('database ready'))
 ```
 

--- a/docs/table.md
+++ b/docs/table.md
@@ -4,7 +4,7 @@
 
 ```javascript
 const differ = new Differ(...)
-const table = differ.define('table', properties)
+const table = differ.define.table(properties)
 table.addSeeds([...])
 differ.sync().then(() => console.log('database ready'))
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -86,20 +86,20 @@ function Differ (options) {
     return version ? Number(version[0]) : null
   }
 
-  const _setup = async () => {
+  const _setup = () => {
     if (schemaFolder) {
       const schemas = _getSchemas({
         placeholders,
         pathFolder: schemaFolder,
         filePattern: /^.*\.schema.json$/,
       })
-      schemas.forEach(define)
+      schemas.forEach(_define)
     }
   }
 
   const _supportSeeds = (currentVersion) => currentVersion >= 9.5
 
-  const define = (type, properties) => {
+  const _define = (type, properties) => {
     if (typeof type === 'object') {
       properties = type.properties
       type = type.type
@@ -273,6 +273,18 @@ function Differ (options) {
     table: (options) => _read('table', options),
     sequence: (options) => _read('sequence', options),
   }
+
+  const define = (type, properties) => {
+    logger.warn(
+      `The method 'define(type, properties)' is deprecated.` +
+      ` Use 'define.table(properties)' or 'define.sequence(properties)'`,
+    )
+    return _define(type, properties)
+  }
+
+  define.table = (properties) => _define('table', properties)
+
+  define.sequence = (properties) => _define('sequence', properties)
 
   _setup()
 

--- a/test/alterColumns.js
+++ b/test/alterColumns.js
@@ -9,7 +9,7 @@ describe('alter columns', () => {
       logging: logging,
     })
 
-    differ.define('table', {
+    differ.define.table({
       name: 'users',
       indexes: [ { columns: [ 'age' ] } ],
       columns: [
@@ -19,7 +19,7 @@ describe('alter columns', () => {
     })
     await differ.sync()
 
-    differ.define('table', {
+    differ.define.table({
       name: 'users',
       cleanable: {
         indexes: true,
@@ -32,7 +32,7 @@ describe('alter columns', () => {
     })
     await differ.sync()
 
-    differ.define('table', {
+    differ.define.table({
       name: 'users',
       columns: [
         { name: 'busy', type: 'smallint' },

--- a/test/reconnection.js
+++ b/test/reconnection.js
@@ -13,7 +13,7 @@ describe('reconnection', () => {
         reconnection: { attempts: 2, delay: 500 },
       })
 
-      differ.define('table', {
+      differ.define.table({
         name: 'users',
         columns: [ { name: 'id', type: 'smallint' } ],
       })

--- a/test/schemaValidation.js
+++ b/test/schemaValidation.js
@@ -10,13 +10,10 @@ describe('schema validation', () => {
     })
 
     try {
-      differ.define({
-        type: 'table',
-        properties: {
-          columns: [
-            { name: 'id', type: 'smallint' },
-          ],
-        },
+      differ.define.table({
+        columns: [
+          { name: 'id', type: 'smallint' },
+        ],
       })
     } catch (e) {
       done()
@@ -48,15 +45,12 @@ describe('schema validation', () => {
       logging: logging,
     })
     try {
-      differ.define({
-        type: 'table',
-        properties: {
-          name: 'some_table',
-          columns: [
-            { name: 'id', type: 'smallint' },
-          ],
-          seeds: [ { id: 1, busy: 'some string with quote \'' } ], // will be a error
-        },
+      differ.define.table({
+        name: 'some_table',
+        columns: [
+          { name: 'id', type: 'smallint' },
+        ],
+        seeds: [ { id: 1, busy: 'some string with quote \'' } ], // will be a error
       })
     } catch (e) {
       done()
@@ -69,7 +63,7 @@ describe('schema validation', () => {
       logging: logging,
     })
 
-    differ.define('table', {
+    differ.define.table({
       name: 'public.blogs',
       columns: [
         { name: 'id', type: 'smallint' },

--- a/test/structureReading.js
+++ b/test/structureReading.js
@@ -11,7 +11,7 @@ describe('reading structure', function () {
   })
 
   it('table', async function () {
-    differ.define('table', {
+    differ.define.table({
       name: 'users',
       columns: [
         { name: 'id', type: 'bigint', autoIncrement: true, primaryKey: true },
@@ -71,7 +71,7 @@ describe('reading structure', function () {
 
   it('sequence', async function () {
     const properties = { name: 'public.users_id_seq', start: '10', min: '10', max: '20' }
-    differ.define('sequence', properties)
+    differ.define.sequence(properties)
 
     await differ.sync()
     const sequence = await differ.read.sequence({ name: properties.name })

--- a/test/sync.js
+++ b/test/sync.js
@@ -17,7 +17,7 @@ describe('sync', () => {
 
     await differ.sync()
 
-    differ.define('table', {
+    differ.define.table({
       name: 'public.blogs',
       cleanable: {
         unique: true,
@@ -49,7 +49,7 @@ describe('sync', () => {
       reconnection: true,
       logging,
     })
-    differ.define('table', {
+    differ.define.table({
       name: 'children',
       force: true,
       foreignKeys: [

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -160,13 +160,23 @@ declare type EntityType = 'table' | 'sequence'
 declare class Differ {
     constructor(options: DifferOptions);
 
-    define(entityType: Schema | EntityType, properties?: TableSchemaOptions | SequenceSchemaOptions): Table | Sequence
-
     sync(): Promise<null>
 
+    define: {
+        /**
+         *
+         * @deprecated
+         */
+        (entityType: Schema | EntityType, properties?: TableSchemaOptions | SequenceSchemaOptions): Table | Sequence
+
+        table(properties: TableSchemaOptions): Table
+
+        sequence(properties: SequenceSchemaOptions): Sequence
+    };
+
     read: {
-        table(options: TableReadOptions): Promise<TableSchemaOptions>,
-        sequence(options: SequenceReadOptions): Promise<SequenceSchemaOptions>,
+        table(options: TableReadOptions): Promise<TableSchemaOptions>
+        sequence(options: SequenceReadOptions): Promise<SequenceSchemaOptions>
     }
 }
 


### PR DESCRIPTION
* defining the `define` function as *deprecated*
* adding functions `define.table` and `define.sequence`